### PR TITLE
Update courey.css

### DIFF
--- a/courey/courey.css
+++ b/courey/courey.css
@@ -9,6 +9,8 @@ background-color : black;
 color : #1fc217;
 font-size : 24px;
 opacity: 0.7;
+position: relative;
+z-index: -1;
 }
 
 h1 {


### PR DESCRIPTION
SoaringBow4 fixed the paragraph element, changing its position to "relative" and its z-index to -1. Now, when the user scrolls down the page, the background color of the paragraph element will no longer go over the navigation bar.