### PR TITLE
Update courey.css

### DIFF
--- a/courey/courey.css
+++ b/courey/courey.css
@@ -72,6 +72,7 @@ float : left;
 li a {
 color : white;
 display : block;
+font-family: "Times New Roman" !important;
 padding : 30px;
 text-align : center;
 text-decoration : none;


### PR DESCRIPTION
SoaringBow4 is overriding the *{ font-family: "Courier New", "Times New Roman", Times; }, for the list names (Previous, Home, and Next) and has made them Times New Roman.